### PR TITLE
Add deepnote/ir-with-libs image

### DIFF
--- a/ir-with-libs/Dockerfile
+++ b/ir-with-libs/Dockerfile
@@ -1,0 +1,10 @@
+FROM deepnote/ir:4.0.3
+
+# Dependencies needed for R libraries
+RUN apt-get update \
+   && apt-get install -y libcurl4-openssl-dev libssl-dev libxml2-dev libcairo2-dev libxt-dev \
+   libpq-dev \
+   libudunits2-dev libgdal-dev libgeos-dev libproj-dev
+
+# Install the R libraries
+RUN R -e "install.packages(c('tidyverse', 'data.table', 'RSQLite', 'remotes', 'reticulate', 'igraph', 'plotly'), lib='/usr/local/lib/R/site-library', dependencies = T)"

--- a/ir-with-libs/README.md
+++ b/ir-with-libs/README.md
@@ -1,0 +1,11 @@
+# R image with preinstalled libraries
+This image is based on `deepnote/ir` and installs the following libraries:
+- tidyverse 
+- data.table 
+- RSQLite 
+- remotes 
+- reticulate 
+- igraph 
+- plotly
+
+See the [Dockerfile](https://github.com/deepnote/environments/blob/main/ir-with-libs/Dockerfile).


### PR DESCRIPTION
Based on the list of packages in https://community.deepnote.com/c/showcase/plotly-in-r-project#comment_wrapper_949599 plus some we got from another user on Crisp (from the same team as the community comment author).

The ideal way to implement this would be to have this installed in a mountable directory and mount it to the image same as what we do with Python packages, but that would be more difficult to set up (we would need to validate it is compatible with different distros etc). This was a (almost) quick win.

The plan is to let to announce this image in the community so that they can use it as Custom Docker Image and can avoid the very lengthy compilation of custom environment. 
Optionally we can also offer it in the Environment dropdown in the Hardware tab.