### PR TITLE
Remove setting R_LIBS_USER from Dockerfile

### DIFF
--- a/ir-with-libs/Dockerfile
+++ b/ir-with-libs/Dockerfile
@@ -1,4 +1,4 @@
-FROM deepnote/ir:4.0.3
+FROM deepnote/ir:4.0.4
 
 # Dependencies needed for R libraries
 RUN apt-get update \

--- a/ir-with-libs/Dockerfile
+++ b/ir-with-libs/Dockerfile
@@ -7,4 +7,4 @@ RUN apt-get update \
    libudunits2-dev libgdal-dev libgeos-dev libproj-dev
 
 # Install the R libraries
-RUN R -e "install.packages(c('tidyverse', 'data.table', 'RSQLite', 'remotes', 'reticulate', 'igraph', 'plotly'), lib='/usr/local/lib/R/site-library', dependencies = T)"
+RUN R -e "install.packages(c('tidyverse', 'data.table', 'RSQLite', 'remotes', 'reticulate', 'igraph', 'plotly'), dependencies = T)"

--- a/ir-with-libs/Dockerfile
+++ b/ir-with-libs/Dockerfile
@@ -8,3 +8,9 @@ RUN apt-get update \
 
 # Install the R libraries
 RUN R -e "install.packages(c('tidyverse', 'data.table', 'RSQLite', 'remotes', 'reticulate', 'igraph', 'plotly'), dependencies = T)"
+
+# Workaround for Java to install correctly
+RUN mkdir -p /usr/share/man/man1/
+RUN apt-get update && apt-get install -y libglu1-mesa-dev mesa-common-dev libhdf5-dev libv8-dev libmagick++-dev libharfbuzz-dev libfribidi-dev r-cran-rjava default-jdk
+RUN R CMD javareconf
+RUN R -e "install.packages(c('rgl', 'hdf5r', 'rJava'), dependencies = T)"

--- a/ir-with-libs/README.md
+++ b/ir-with-libs/README.md
@@ -6,6 +6,9 @@ This image is based on `deepnote/ir` and installs the following libraries:
 - remotes 
 - reticulate 
 - igraph 
-- plotly
+- plotly 
+- rgl 
+- hdf5r 
+- rJava
 
 See the [Dockerfile](https://github.com/deepnote/environments/blob/main/ir-with-libs/Dockerfile).

--- a/ir/Dockerfile
+++ b/ir/Dockerfile
@@ -30,6 +30,5 @@ RUN pip install notebook
 RUN sudo R -e "install.packages('IRkernel', repos='http://cran.rstudio.com/')"
 RUN R -e "IRkernel::installspec()"
 
-ENV R_LIBS_USER "~/work/.R/library"
 # Set default kernel to R
 ENV DEFAULT_KERNEL_NAME "ir"

--- a/ir/Dockerfile
+++ b/ir/Dockerfile
@@ -4,7 +4,7 @@ FROM deepnote/python:3.7
 RUN echo "deb http://http.debian.net/debian sid main" > /etc/apt/sources.list.d/debian-unstable.list \
         && echo 'APT::Install-Recommends "false";' > /etc/apt/apt.conf.d/90local-no-recommends
 
-ARG R_BASE_VERSION=4.0.3
+ARG R_BASE_VERSION=4.0.4
 ## Now install R and littler, and create a link for littler in /usr/local/bin
 RUN apt-get update \
         && apt-get install -t unstable -y --no-install-recommends \

--- a/readme.md
+++ b/readme.md
@@ -1,21 +1,19 @@
 # Quick reference
- * Mantained by: [Deepnote](https://deepnote.com/)
+ * Maintained by: [Deepnote](https://deepnote.com/)
  * Where to get help: [Community](https://community.deepnote.com/join?invitation_token=0ba08a2332e8ec002f56f8c1eefdb5bc49af0bae-ff6f0d9b-5045-4511-b6d3-a4fe2595c951)
 
-### Python image
----
+## Python image
 * [`3.6`, `3.7`, `3.8`, `3.9`](https://github.com/deepnote/environments/blob/main/python/Dockerfile)
 
-#### How to build 
+### How to build 
 ```
 docker build -t deepnote/python:<TAG>  --build-arg PYTHON_VERSION=<some_version> ./python
 ```
 
-### R image
----
-* [`3.5.2`, `4.0.3`](https://github.com/deepnote/environments/blob/main/ir/Dockerfile)
+## R image
+* [`3.5.2`, `4.0.4`](https://github.com/deepnote/environments/blob/main/ir/Dockerfile)
 
-#### How to build 
+### How to build 
 ```
 docker build -t deepnote/ir:<TAG>  --build-arg R_BASE_VERSION=<some_version> ./ir
 ```


### PR DESCRIPTION
This has been moved to project startup script. This makes it easier to build images on top of `deepnote/ir`.

This also bumps R to 4.0.4, because 4.0.3 is no longer available in Debian repos.

Lastly, this adds more libraries to `deepnote/ir-with-libs`, as discussed in [community](https://community.deepnote.com/c/showcase/plotly-in-r-project)