### PR TITLE
Deeepnote GPU image

### DIFF
--- a/gpu/Dockerfile
+++ b/gpu/Dockerfile
@@ -1,0 +1,6 @@
+FROM tensorflow/tensorflow:2.4.1-gpu
+
+RUN apt-get update \
+  && apt-get install -yq --no-install-recommends \
+  git sudo \
+  && rm -rf /var/lib/apt/lists/*

--- a/readme.md
+++ b/readme.md
@@ -13,6 +13,11 @@ docker build -t deepnote/python:<TAG>  --build-arg PYTHON_VERSION=<some_version>
 ## R image
 * [`3.5.2`, `4.0.4`](https://github.com/deepnote/environments/blob/main/ir/Dockerfile)
 
+## GPU image
+The image is based on tensorflow docker image and adds packages that are typical part of our other images (`git` most importantly).
+
+We follow the tagging of `tensorflow` image. So `tensorflow/tensorflow:2.4.1-gpu` becomes `deepnote/tensorflow:2.4.1-gpu`.
+
 ### How to build 
 ```
 docker build -t deepnote/ir:<TAG>  --build-arg R_BASE_VERSION=<some_version> ./ir


### PR DESCRIPTION
The default tensorflow is mostly missing `git`, which is something we should have in our official images.
For full compatibility with out other images, `sudo` is added as well (although basically not necessary).