### PR TITLE
Add R 4.2.0

### DIFF
--- a/ir/Dockerfile
+++ b/ir/Dockerfile
@@ -1,14 +1,15 @@
-FROM deepnote/python:3.7
+# TODO: Using debian:sid as the base does not provide very good reproducibility of the build
+FROM debian:sid
 
-## Use Debian unstable via pinning -- new style via APT::Default-Release
-RUN echo "deb http://http.debian.net/debian sid main" > /etc/apt/sources.list.d/debian-unstable.list \
-        && echo 'APT::Install-Recommends "false";' > /etc/apt/apt.conf.d/90local-no-recommends
+RUN echo 'APT::Install-Recommends "false";' > /etc/apt/apt.conf.d/90local-no-recommends
+RUN apt update && apt -y install sudo python-is-python3 python3-pip && rm -rf /var/lib/apt/lists/*
 
-ARG R_BASE_VERSION=4.0.4
+ARG R_BASE_VERSION=4.2.0
+
 ## Now install R and littler, and create a link for littler in /usr/local/bin
 RUN apt-get update \
-        && apt-get install -t unstable -y --no-install-recommends \
-        gcc-8-base \
+        && apt-get install -y --no-install-recommends \
+        gcc \
         libopenblas0-pthread \
 		littler \
         r-cran-littler \

--- a/readme.md
+++ b/readme.md
@@ -11,7 +11,7 @@ docker build -t deepnote/python:<TAG>  --build-arg PYTHON_VERSION=<some_version>
 ```
 
 ## R image
-* [`3.5.2`, `4.0.4`](https://github.com/deepnote/environments/blob/main/ir/Dockerfile)
+* [`3.5.2`, `4.0.4`, `4.2.0`](https://github.com/deepnote/environments/blob/main/ir/Dockerfile)
 
 ## GPU image
 The image is based on tensorflow docker image and adds packages that are typical part of our other images (`git` most importantly).


### PR DESCRIPTION
Using the previous approach of building on top of `deepnote/python:3.7` (which is a small layer on top of `python:3.7-slib-buster`) and then adding `sid` deb repositories did not work (there were some conflicting / broken packages). I have therefore based the R image on `debian:sid` directly to get compatible deb packages.

I have tried basing it on top of some pinned Debian version (namely `buster` or `bullseye`), but none of them had R 4.2.0.

Going forward, we should consider using a more stable base image than the Debian `sid` (testing).