### PR TITLE
Allow setting base tensorflow image

### DIFF
--- a/gpu/Dockerfile
+++ b/gpu/Dockerfile
@@ -1,4 +1,5 @@
-FROM tensorflow/tensorflow:2.6.0-gpu
+ARG TENSORFLOW_IMAGE_TAG=2.9.1-gpu
+FROM tensorflow/tensorflow:${TENSORFLOW_IMAGE_TAG}
 
 RUN apt-get update \
   && apt-get install -yq --no-install-recommends \


### PR DESCRIPTION
This helps releasing `deepnote/tensorflow:2.9.1-gpu` (already built and pushed).