### PR TITLE
Build bullseye variant of Python images

### DIFF
--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -1,5 +1,6 @@
 ARG PYTHON_VERSION=3.7
-FROM python:${PYTHON_VERSION}-slim-buster
+ARG DEBIAN_VERSION=buster
+FROM python:${PYTHON_VERSION}-slim-${DEBIAN_VERSION}
 ENV DEBIAN_FRONTEND noninteractive
 
 # Install OS dependencies

--- a/python/hooks/build
+++ b/python/hooks/build
@@ -1,5 +1,6 @@
 #!/bin/bash
 cat "python-versions.txt" | while read PYTHON_VERSION
 do
-    docker build --build-arg PYTHON_VERSION=$PYTHON_VERSION -t $DOCKER_REPO:$PYTHON_VERSION .
+    docker build --build-arg PYTHON_VERSION=$PYTHON_VERSION -t $DOCKER_REPO:${PYTHON_VERSION} .
+    docker build --build-arg PYTHON_VERSION=$PYTHON_VERSION --build-arg DEBIAN_VERSION=bullseye -t $DOCKER_REPO:${PYTHON_VERSION}-bullseye .
 done

--- a/python/hooks/push
+++ b/python/hooks/push
@@ -2,4 +2,5 @@
 cat "python-versions.txt" | while read PYTHON_VERSION
 do
     docker push $DOCKER_REPO:$PYTHON_VERSION
+    docker push $DOCKER_REPO:$PYTHON_VERSION-bullseye
 done


### PR DESCRIPTION
We need the bullseye as the base for the Conda images.

I have also considered switching the existing images from `buster` to `bullseye`, but creating new tag instead of overwriting the existing one seems much safer for reproducibility.