### PR TITLE
Add Anaconda python image

### DIFF
--- a/python/Dockerfile.conda
+++ b/python/Dockerfile.conda
@@ -1,0 +1,17 @@
+ARG PYTHON_VERSION=3.7
+FROM deepnote/python:${PYTHON_VERSION}-bullseye
+
+RUN MINICONDA_URL="https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh"; \
+    wget --quiet $MINICONDA_URL -O /tmp/miniconda.sh && \
+    /bin/bash /tmp/miniconda.sh -b -p /opt/conda && \
+    rm /tmp/miniconda.sh && \
+    /opt/conda/bin/conda clean --all --yes
+
+ENV PATH /opt/conda/bin:$PATH
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        tini  \
+        libglib2.0-0 libxext6 libsm6 libxrender1 && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*

--- a/python/hooks/build
+++ b/python/hooks/build
@@ -1,6 +1,7 @@
 #!/bin/bash
 cat "python-versions.txt" | while read PYTHON_VERSION
 do
-    docker build --build-arg PYTHON_VERSION=$PYTHON_VERSION -t $DOCKER_REPO:${PYTHON_VERSION} .
-    docker build --build-arg PYTHON_VERSION=$PYTHON_VERSION --build-arg DEBIAN_VERSION=bullseye -t $DOCKER_REPO:${PYTHON_VERSION}-bullseye .
+    docker build --build-arg PYTHON_VERSION=${PYTHON_VERSION} -t ${DOCKER_REPO}:${PYTHON_VERSION} .
+    docker build --build-arg PYTHON_VERSION=${PYTHON_VERSION} --build-arg DEBIAN_VERSION=bullseye -t $DOCKER_REPO:${PYTHON_VERSION}-bullseye .
+    docker build --build-arg PYTHON_VERSION=${PYTHON_VERSION} -t ${DOCKER_REPO}:${PYTHON_VERSION}-conda . --file Dockerfile.conda
 done

--- a/python/hooks/push
+++ b/python/hooks/push
@@ -1,6 +1,7 @@
 #!/bin/bash
 cat "python-versions.txt" | while read PYTHON_VERSION
 do
-    docker push $DOCKER_REPO:$PYTHON_VERSION
-    docker push $DOCKER_REPO:$PYTHON_VERSION-bullseye
+    docker push ${DOCKER_REPO}:${PYTHON_VERSION}
+    docker push ${DOCKER_REPO}:${PYTHON_VERSION}-bullseye
+    docker push ${DOCKER_REPO}:${PYTHON_VERSION}-conda
 done


### PR DESCRIPTION
Builds on top of `deepnote/python:x-bullseye`, as some Conda packages (`pytorch` namely) rely on too new version of glibc and did not work with `buster`.