### PR TITLE
Install the correct Python version in Conda

### DIFF
--- a/python/Dockerfile.conda
+++ b/python/Dockerfile.conda
@@ -23,7 +23,7 @@ RUN MINICONDA_URL="https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x
     rm /tmp/miniconda.sh && \
     # Install the correct version of python (as the time of
     # writing, anaconda installed python 3.9 by default)
-    /opt/conda/bin/conda install python=${PYTHON_VERSION} && \
+    /opt/conda/bin/conda install python=${FROM_PYTHON_VERSION} && \
     /opt/conda/bin/conda clean --all
 
 ENV PATH=/opt/conda/bin:$PATH

--- a/python/Dockerfile.conda
+++ b/python/Dockerfile.conda
@@ -10,15 +10,23 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
+ENV CONDA_ALWAYS_YES=true
+
+# We always download and install the latest miniconda3,
+# and then downgrade python to specific version.
+# We could instead download a specific miniconda3 version,
+# but that would require baking in the URLs for
+# different Miniconda installer versions into the Dockerfile.
 RUN MINICONDA_URL="https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh"; \
     wget --quiet $MINICONDA_URL -O /tmp/miniconda.sh && \
     /bin/bash /tmp/miniconda.sh -b -p /opt/conda && \
     rm /tmp/miniconda.sh && \
-    /opt/conda/bin/conda clean --all --yes
+    # Install the correct version of python (as the time of
+    # writing, anaconda installed python 3.9 by default)
+    /opt/conda/bin/conda install python=${PYTHON_VERSION} && \
+    /opt/conda/bin/conda clean --all
 
 ENV PATH=/opt/conda/bin:$PATH
-
-ENV CONDA_ALWAYS_YES=true
 
 ENV PIP_TARGET=/opt/conda/lib/python${FROM_PYTHON_VERSION}/site-packages
 

--- a/readme.md
+++ b/readme.md
@@ -12,7 +12,7 @@ docker build -t deepnote/python:<TAG>  --build-arg FROM_PYTHON_VERSION=<some_ver
 
 ## Conda images
 For every Python version (see above), we also build a `-conda` variant, which includes [Miniconda](https://docs.conda.io/en/latest/miniconda.html) installation.
-The Dockerfile for this is at [./python/Dockerfile-conda](https://github.com/deepnote/environments/blob/main/python/Dockerfile-conda).
+The Dockerfile for this is at [./python/Dockerfile.conda](./python/Dockerfile.conda).
 
 ### How to build
 ```

--- a/readme.md
+++ b/readme.md
@@ -10,6 +10,15 @@
 docker build -t deepnote/python:<TAG>  --build-arg FROM_PYTHON_VERSION=<some_version> ./python
 ```
 
+## Conda images
+For every Python version (see above), we also build a `-conda` variant, which includes [Miniconda](https://docs.conda.io/en/latest/miniconda.html) installation.
+The Dockerfile for this is at [./python/Dockerfile-conda](https://github.com/deepnote/environments/blob/main/python/Dockerfile-conda).
+
+### How to build
+```
+docker build --build-arg FROM_PYTHON_VERSION=<some_version> -t deepnote/python:<some_version>-conda ./python --file .python/Dockerfile.conda
+```
+
 ## R image
 * [`3.5.2`, `4.0.4`, `4.2.0`](https://github.com/deepnote/environments/blob/main/ir/Dockerfile)
 
@@ -25,3 +34,6 @@ docker build -t deepnote/ir:<TAG>  --build-arg R_BASE_VERSION=<some_version> ./i
 The image is based on tensorflow docker image and adds packages that are typical part of our other images (`git` most importantly).
 
 We follow the tagging of `tensorflow` image. So `tensorflow/tensorflow:2.4.1-gpu` becomes `deepnote/tensorflow:2.4.1-gpu`.
+
+## Continuous integration
+Some images are built automatically using the Docker Hub build. See [Docker Hub Builds](https://hub.docker.com/repository/docker/deepnote/python/builds) for more details.


### PR DESCRIPTION
Before this, Python 3.9 would be installed in all conda images, which caused issues for Conda 3.8 and other images.