### PR TITLE
Add DEEPNOTE_PYTHON_KERNEL_ONLY to images

### DIFF
--- a/gpu/Dockerfile
+++ b/gpu/Dockerfile
@@ -5,3 +5,5 @@ RUN apt-get update \
   && apt-get install -yq --no-install-recommends \
   git sudo \
   && rm -rf /var/lib/apt/lists/*
+
+ENV DEEPNOTE_PYTHON_KERNEL_ONLY=true

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -25,7 +25,8 @@ RUN apt-get update && apt-get -yq dist-upgrade \
 ENV SHELL=/bin/bash \
   LC_ALL=en_US.UTF-8 \
   LANG=en_US.UTF-8 \
-  LANGUAGE=en_US.UTF-8 
+  LANGUAGE=en_US.UTF-8 \
+  DEEPNOTE_PYTHON_KERNEL_ONLY=true
 
 RUN echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && \
   locale-gen


### PR DESCRIPTION
Add the `DEEPNOTE_PYTHON_KERNEL_ONLY` variable to our public images with only python kernel. On the base of this variable startup script will skip setup for non-python kernels added here https://github.com/deepnote/compute-helpers/pull/24