### PR TITLE
Rebuild datascience images

### DIFF
--- a/gpu/setup.python.sh
+++ b/gpu/setup.python.sh
@@ -32,6 +32,13 @@ ln -s /usr/bin/python3 /usr/bin/python
 pip uninstall -y cryptography
 pip install numpy==1.23.4 tensorflow==$TF_VERSION -c https://tk.deepnote.com/constraints${PYTHON_VER}.txt
 
+for src in idle3 pip3 pydoc3 python3 python3-config; do \
+		dst="$(echo "$src" | tr -d 3)"; \
+		[ -s "/usr/local/bin/$src" ]; \
+		[ ! -e "/usr/local/bin/$dst" ]; \
+		ln -svT "$src" "/usr/local/bin/$dst"; \
+done
+
 # create the virtual environment in the home directory in the Dockerfile
 # using our upgraded python version
 python"$PYTHON_VER" -m venv --system-site-packages ~/venv

--- a/gpu/setup.python.sh
+++ b/gpu/setup.python.sh
@@ -32,13 +32,6 @@ ln -s /usr/bin/python3 /usr/bin/python
 pip uninstall -y cryptography
 pip install numpy==1.23.4 tensorflow==$TF_VERSION -c https://tk.deepnote.com/constraints${PYTHON_VER}.txt
 
-for src in idle3 pip3 pydoc3 python3 python3-config; do 
-		dst="$(echo "$src" | tr -d 3)"; 
-		[ -s "/usr/local/bin/$src" ]; 
-		[ ! -e "/usr/local/bin/$dst" ]; 
-		ln -svT "$src" "/usr/local/bin/$dst"; 
-done
-
 # create the virtual environment in the home directory in the Dockerfile
 # using our upgraded python version
 python"$PYTHON_VER" -m venv --system-site-packages ~/venv

--- a/gpu/setup.python.sh
+++ b/gpu/setup.python.sh
@@ -32,11 +32,11 @@ ln -s /usr/bin/python3 /usr/bin/python
 pip uninstall -y cryptography
 pip install numpy==1.23.4 tensorflow==$TF_VERSION -c https://tk.deepnote.com/constraints${PYTHON_VER}.txt
 
-for src in idle3 pip3 pydoc3 python3 python3-config; do \
-		dst="$(echo "$src" | tr -d 3)"; \
-		[ -s "/usr/local/bin/$src" ]; \
-		[ ! -e "/usr/local/bin/$dst" ]; \
-		ln -svT "$src" "/usr/local/bin/$dst"; \
+for src in idle3 pip3 pydoc3 python3 python3-config; do 
+		dst="$(echo "$src" | tr -d 3)"; 
+		[ -s "/usr/local/bin/$src" ]; 
+		[ ! -e "/usr/local/bin/$dst" ]; 
+		ln -svT "$src" "/usr/local/bin/$dst"; 
 done
 
 # create the virtual environment in the home directory in the Dockerfile

--- a/python/readme.md
+++ b/python/readme.md
@@ -9,7 +9,6 @@
 Deepnote Python is a set of Docker images tailored for use in the Deepnote platform. These images are based on the official [Python Docker images](https://hub.docker.com/_/python) and include additional binaries and configurations to enhance the user experience within Deepnote. They are designed to simplify development workflows, especially for data science projects, by providing pre-configured environments that are ready to use.
 
 # How to Use This Image
-
 ## Create Custom Dockerfile for Deepnote Use
 To create a custom Dockerfile using Deepnote's Python image, you can start with the following template:
 


### PR DESCRIPTION
Removing space to rebuild datascience images to fix lsp in Python 3.11 by installing upgraded version of `parso` and `jedi` (parso specifically should be 0.8+) based on updated constraints. You can check if it's working by hovering on function (simple hover on print in `print("hello")` will do):
- [Project with rebuilt environment](https://deepnote-staging.com/workspace/Deepnote-b29c5ffe-318b-4d24-9726-ff78fc714ef2/project/Oleh-Korniienkos-Untitled-project-09b33b5a-d861-4f59-9864-dd55bd8af3ac/notebook/Execution-context-repro-870b2826510b474e8793b6a5c1bcd7f9)
- [Project with old environment](https://deepnote-staging.com/workspace/Deepnote-b29c5ffe-318b-4d24-9726-ff78fc714ef2/project/Michal-Franczels-Untitled-project-036bd3db-6b1c-418e-a532-f452cef6ddaa/notebook/5c3e365b6fb147c092e649ec4ae8bd10)

