### PR TITLE
Build multi-arch images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,8 +46,7 @@ jobs:
               --tag=978928340082.dkr.ecr.us-east-1.amazonaws.com/${REPOSITORY}:${TAG}${TAG_SUFFIX} \
               --tag=docker.io/${REPOSITORY}:${TAG}${TAG_SUFFIX} \
               --progress plain \
-              --platform linux/amd64 \
-              --platform linux/arm64 \
+              --platform linux/amd64,linux/arm64 \
               --provenance=false \
               --sbom=false \
               --output type=registry,push=true \
@@ -79,8 +78,7 @@ jobs:
               --tag=docker.io/${REPOSITORY}:${TAG}${TAG_SUFFIX} \
               --build-arg CIRCLE_PULL_REQUEST=${CIRCLE_PULL_REQUEST} \
               --progress plain \
-              --platform linux/amd64 \
-              --platform linux/arm64 \
+              --platform linux/amd64,linux/arm64 \
               --provenance=false \
               --sbom=false \
               --output type=registry,push=true \
@@ -111,8 +109,7 @@ jobs:
               --build-arg CIRCLE_PULL_REQUEST=${CIRCLE_PULL_REQUEST} \
               --build-arg PYTHON_VERSION=${PYTHON_VERSION} \
               --progress plain \
-              --platform linux/amd64 \
-              --platform linux/arm64 \
+              --platform linux/amd64,linux/arm64 \
               --provenance=false \
               --sbom=false \
               --output type=registry,push=true \

--- a/python/conda/Dockerfile.conda
+++ b/python/conda/Dockerfile.conda
@@ -18,13 +18,20 @@ ENV CONDA_ALWAYS_YES=true
 # but that would require baking in the URLs for
 # different Miniconda installer versions into the Dockerfile.
 ARG PYTHON_VERSION
-RUN wget --quiet "https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh" -O /tmp/miniconda.sh && \
+ARG TARGETARCH
+RUN case "$TARGETARCH" in \
+      amd64) MINICONDA_ARCH="x86_64" ;; \
+      arm64) MINICONDA_ARCH="aarch64" ;; \
+      *) echo "Unsupported TARGETARCH: $TARGETARCH" >&2; exit 1 ;; \
+    esac && \
+    wget --quiet "https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-${MINICONDA_ARCH}.sh" -O /tmp/miniconda.sh && \
     /bin/bash /tmp/miniconda.sh -b -p /opt/conda && \
     rm /tmp/miniconda.sh && \
     # Use community packages from conda-forge instead of Anaconda Inc. default channels
     # which require accepting terms of service & using commercial license for orgs with more than 200 employees
     /opt/conda/bin/conda config --add channels conda-forge && \
-    /opt/conda/bin/conda config --remove channels defaults && \
+    /opt/conda/bin/conda config --remove channels defaults || true && \
+    /opt/conda/bin/conda config --set channel_priority strict && \
     # Install the correct version of python (as the time of writing, anaconda 
     # installed python 3.11 by default) for parity with our base image
     /opt/conda/bin/conda install python=${PYTHON_VERSION} && \


### PR DESCRIPTION
Build base and Python images for arm64 so they can be used on M-series MacBooks without emulation (Rosetta)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Docker images now support multi-architecture builds (including ARM64), enabling use on Apple Silicon and ARM servers.
  * Conda-based images install the correct Miniconda for each architecture and default to the conda-forge channel.

* Chores
  * CI pipeline updated to accommodate longer build times (extended step timeout).
  * Build caching configuration simplified by removing registry-based cache options to streamline builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->