### PR TITLE
Add R 4.4.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -342,7 +342,7 @@ workflows:
               r-version: *python310-r-versions
           python-version: "3.10"
           requires:
-            - Python 3.10
+            - R << matrix.r-version >>
       - build-and-push-gpu:
           name: Tensorflow 2.9, Cuda 12.6, Ubuntu 20.04
           cuda-version: "12.6.3"


### PR DESCRIPTION
Adds new environment for R 4.4.3. It also will be first R env to be based on Python 3.10 since we want to deprecate Python 3.9 this year.