### PR TITLE
fix: Remove hardcoded numpy version from TensorFlow installation

### DIFF
--- a/gpu/setup.python.sh
+++ b/gpu/setup.python.sh
@@ -30,7 +30,7 @@ ln -s /usr/bin/python3 /usr/bin/python
 
 # We need to remove some pre-installed pip packages that end up clashing with our compute-deps
 pip uninstall -y cryptography
-pip install numpy==1.23.4 tensorflow==$TF_VERSION -c https://tk.deepnote.com/constraints${PYTHON_VER}.txt
+pip install numpy tensorflow==$TF_VERSION -c https://tk.deepnote.com/constraints${PYTHON_VER}.txt
 
 # create the virtual environment in the home directory in the Dockerfile
 # using our upgraded python version


### PR DESCRIPTION
The hardcoded numpy==1.23.4 was causing TensorFlow 2.15.0 installation to fail as it requires numpy>=1.23.5. Letting pip resolve the numpy version allows each TensorFlow version to install its compatible numpy version within our constraints.