### PR TITLE
feat: Build new tensorflow environments

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -342,6 +342,33 @@ workflows:
           python-version: "3.10"
           requires:
             - R << matrix.r-version >>
+
+      - build-and-push-gpu:
+          name: Tensorflow 2.15, Cuda 11.8, Ubuntu 22.04
+          cuda-version: "11.8.0"
+          ubuntu-version: "22.04"
+          tf-version: "2.15.1"
+          python-version: "3.11"
+      - build-and-push-gpu:
+          name: Tensorflow 2.15, Cuda 12.6, Ubuntu 22.04
+          cuda-version: "12.6.3"
+          ubuntu-version: "22.04"
+          tf-version: "2.15.1"
+          python-version: "3.11"
+      - build-and-push-gpu:
+          name: Tensorflow 2.17, Cuda 12.6, Ubuntu 24.04
+          cuda-version: "12.6.3"
+          ubuntu-version: "24.04"
+          tf-version: "2.17.1"
+          python-version: "3.11"
+      - build-and-push-gpu:
+          name: Tensorflow 2.19, Cuda 12.6, Ubuntu 24.04
+          cuda-version: "12.6.3"
+          ubuntu-version: "24.04"
+          tf-version: "2.19.1"
+          python-version: "3.11"
+
+      # To be deprecated
       - build-and-push-gpu:
           name: Tensorflow 2.9, Cuda 12.6, Ubuntu 20.04
           cuda-version: "12.6.3"
@@ -355,13 +382,6 @@ workflows:
           tf-version: "2.11.1"
           python-version: "3.10"
       - build-and-push-gpu:
-          name: Tensorflow 2.15, Cuda 12.6, Ubuntu 22.04
-          cuda-version: "12.6.3"
-          ubuntu-version: "22.04"
-          tf-version: "2.15.0"
-          python-version: "3.11"
-
-      - build-and-push-gpu:
           name: Tensorflow 2.9, Cuda 11.8, Ubuntu 20.04
           cuda-version: "11.8.0"
           ubuntu-version: "20.04"
@@ -373,9 +393,3 @@ workflows:
           ubuntu-version: "20.04"
           tf-version: "2.11.1"
           python-version: "3.10"
-      - build-and-push-gpu:
-          name: Tensorflow 2.15, Cuda 11.8, Ubuntu 22.04
-          cuda-version: "11.8.0"
-          ubuntu-version: "22.04"
-          tf-version: "2.15.0"
-          python-version: "3.11"


### PR DESCRIPTION
## Summary 

### New TensorFlow Versions
  - TF 2.17.1 with CUDA 12.6 on Ubuntu 24.04
  - TF 2.19.1 with CUDA 12.6 on Ubuntu 24.04

### Current version (not to be deprecated)

 - TF 2.15.1 with CUDA 11.8 on Ubuntu 22.04
 - TF 2.15.1 with CUDA 12.6 on Ubuntu 22.04

### Versions that will be deprecated
  - TF 2.9.1 with CUDA 12.6.3 on Ubuntu 20.04
  - TF 2.9.1 with CUDA 11.8.0 on Ubuntu 20.04
  - TF 2.11.1 with CUDA 12.6.3 on Ubuntu 20.04
  - TF 2.11.1 with CUDA 11.8.0 on Ubuntu 20.04


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added four new GPU build variants: TF 2.15.1 (CUDA 11.8/12.6 on Ubuntu 22.04), TF 2.17.1 (CUDA 12.6 on Ubuntu 24.04), and TF 2.19.1 (CUDA 12.6 on Ubuntu 24.04), all with Python 3.11.

- Chores
  - Retired older TF 2.15.0 GPU variants in favor of 2.15.1.
  - Added a deprecation note for the TF 2.9 GPU configuration (no immediate change in availability).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->